### PR TITLE
Support offset arg in pluralTypeHandler

### DIFF
--- a/source/pluralTypeHandler.js
+++ b/source/pluralTypeHandler.js
@@ -67,7 +67,7 @@ function replaceNumberSign(caseBody, value) {
  * See https://formatjs.io/docs/core-concepts/icu-syntax#plural-format for more
  * details on how the `plural` statement works.
  * 
- * @param {Number|String} value
+ * @param {String} value
  * @param {String} matches
  * @param {String} locale
  * @param {String} values
@@ -75,19 +75,27 @@ function replaceNumberSign(caseBody, value) {
  * @return {String}
  */
 export default function pluralTypeHandler(value, matches = '', locale, values, format) {
+	const { args, cases } = parseCases(matches);
+
+	let intValue = parseInt(value); 
+
+	args.forEach((arg) => {
+		if (arg.startsWith('offset:')) {
+			intValue -= parseInt(arg.slice('offset:'.length));
+		}
+	});
+
 	const keywordPossibilities = [];
 
-	if (value === 1) {
+	if (intValue === 1) {
 		keywordPossibilities.push(ONE);
 	}
-	keywordPossibilities.push(`=${value}`, OTHER);
-
-	const { cases } = parseCases(matches);
+	keywordPossibilities.push(`=${intValue}`, OTHER);
 
 	for (let i = 0; i < keywordPossibilities.length; i++) {
 		const keyword = keywordPossibilities[i];
 		if (keyword in cases) {
-			const { caseBody, numberValues } = replaceNumberSign(cases[keyword], value);
+			const { caseBody, numberValues } = replaceNumberSign(cases[keyword], intValue);
 			return format(caseBody, {
 				...values,
 				...numberValues

--- a/source/pluralTypeHandler.js
+++ b/source/pluralTypeHandler.js
@@ -77,7 +77,7 @@ function replaceNumberSign(caseBody, value) {
 export default function pluralTypeHandler(value, matches = '', locale, values, format) {
 	const { args, cases } = parseCases(matches);
 
-	let intValue = parseInt(value); 
+	let intValue = parseInt(value);
 
 	args.forEach((arg) => {
 		if (arg.startsWith('offset:')) {

--- a/source/pluralTypeHandler.test.js
+++ b/source/pluralTypeHandler.test.js
@@ -105,6 +105,40 @@ describe('pluralTypeHandler', function() {
 		});
 	});
 
+	describe('Supports offset argument', function () {
+		const formatter = new MessageFormatter('en-NZ', {
+			plural: pluralTypeHandler
+		});
+		
+		test('If unspecified, offset is null', function () {
+			let message = '{days, plural, one {one day} =2 {two days} other {# days}}...';
+
+			let result = formatter.format(message, { days: 5 });
+			expect(result).toBe('5 days...');
+		});
+
+		test('Specified offset will be applied via =X branch', function () {
+			let message = '{days, plural, offset:3 one {one day} =2 {two days} other {# days}}...';
+
+			let result = formatter.format(message, { days: 5 });
+			expect(result).toBe('two days...');
+		});
+
+		test('Specified offset will be applied via number sign', function () {
+			let message = '{days, plural, offset:1 one {one day} =2 {two days} other {# days}}...';
+
+			let result = formatter.format(message, { days: 5 });
+			expect(result).toBe('4 days...');
+		});
+
+		test('Specified offset will be applied via `one` keyword', function () {
+			let message = '{days, plural, offset:4 one {one day} =2 {two days} other {# days}}...';
+
+			let result = formatter.format(message, { days: 5 });
+			expect(result).toBe('one day...');
+		});
+	});
+
 	describe('Empty matches', function() {
 		test('No matching branch', function() {
 			let result = pluralTypeHandler('some value');

--- a/source/pluralTypeHandler.test.js
+++ b/source/pluralTypeHandler.test.js
@@ -105,33 +105,33 @@ describe('pluralTypeHandler', function() {
 		});
 	});
 
-	describe('Supports offset argument', function () {
+	describe('Supports offset argument', function() {
 		const formatter = new MessageFormatter('en-NZ', {
 			plural: pluralTypeHandler
 		});
-		
-		test('If unspecified, offset is null', function () {
+
+		test('If unspecified, offset is null', function() {
 			let message = '{days, plural, one {one day} =2 {two days} other {# days}}...';
 
 			let result = formatter.format(message, { days: 5 });
 			expect(result).toBe('5 days...');
 		});
 
-		test('Specified offset will be applied via =X branch', function () {
+		test('Specified offset will be applied via =X branch', function() {
 			let message = '{days, plural, offset:3 one {one day} =2 {two days} other {# days}}...';
 
 			let result = formatter.format(message, { days: 5 });
 			expect(result).toBe('two days...');
 		});
 
-		test('Specified offset will be applied via number sign', function () {
+		test('Specified offset will be applied via number sign', function() {
 			let message = '{days, plural, offset:1 one {one day} =2 {two days} other {# days}}...';
 
 			let result = formatter.format(message, { days: 5 });
 			expect(result).toBe('4 days...');
 		});
 
-		test('Specified offset will be applied via `one` keyword', function () {
+		test('Specified offset will be applied via `one` keyword', function() {
 			let message = '{days, plural, offset:4 one {one day} =2 {two days} other {# days}}...';
 
 			let result = formatter.format(message, { days: 5 });


### PR DESCRIPTION
Add tests and support for the plural type handler's offset arg. This arg is widely supported in other message formatting libraries, and isn't particularly difficult to implement now that #8 has been merged