### PR TITLE
Add rich formatting method

### DIFF
--- a/source/MessageFormatter.js
+++ b/source/MessageFormatter.js
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import {findClosingBracket, splitFormattedArgument} from './utilities.js';
+import {findClosingBracket, replaceRichTags, splitFormattedArgument} from './utilities.js';
 
 import {flatten} from '@ultraq/array-utils';
 import {memoize} from '@ultraq/function-utils';
+import { defaultRichHandler } from './defaultRichHandler.js';
 
 /**
  * The main class for formatting messages.
@@ -36,10 +37,11 @@ export default class MessageFormatter {
 	 *   their values being the functions that will return a nicely formatted
 	 *   string for the data and locale they are given.
 	 */
-	constructor(locale, typeHandlers = {}) {
+	constructor(locale, typeHandlers = {}, richHandler = null) {
 
 		this.locale = locale;
 		this.typeHandlers = typeHandlers;
+		this.richHandler = richHandler ? richHandler : defaultRichHandler;
 	}
 
 	/**
@@ -55,6 +57,12 @@ export default class MessageFormatter {
 		return flatten(this.process(message, values)).join('');
 	})
 
+	rich(message, values = {}) {
+		const formatted = flatten(this.process(message, values));
+
+		return replaceRichTags(formatted, values, this.richHandler);
+	}
+
 	/**
 	 * Process an ICU message syntax string using `values` for placeholder data
 	 * and any currently-registered type handlers.  The result of this method is
@@ -68,6 +76,7 @@ export default class MessageFormatter {
 	 * 
 	 * @param {String} message
 	 * @param {Object} [values={}]
+	 * @param {}
 	 * @return {Array}
 	 */
 	process(message, values = {}) {
@@ -107,6 +116,7 @@ export default class MessageFormatter {
 				throw new Error(`Unbalanced curly braces in string: "${message}"`);
 			}
 		}
+	
 		return [message];
 	}
 }

--- a/source/MessageFormatter.js
+++ b/source/MessageFormatter.js
@@ -36,6 +36,10 @@ export default class MessageFormatter {
 	 *   Optional object where the keys are the names of the types to register,
 	 *   their values being the functions that will return a nicely formatted
 	 *   string for the data and locale they are given.
+	 * @param {Function} [richHandler=null]
+	 *   A function that takes an identified tag name, the set of provided values,
+	 *   and contents for that tag, and returns a populated element. The element
+	 *   may be anything, so any framework is supported.
 	 */
 	constructor(locale, typeHandlers = {}, richHandler = null) {
 
@@ -76,7 +80,6 @@ export default class MessageFormatter {
 	 * 
 	 * @param {String} message
 	 * @param {Object} [values={}]
-	 * @param {}
 	 * @return {Array}
 	 */
 	process(message, values = {}) {
@@ -116,7 +119,7 @@ export default class MessageFormatter {
 				throw new Error(`Unbalanced curly braces in string: "${message}"`);
 			}
 		}
-	
+
 		return [message];
 	}
 }

--- a/source/MessageFormatter.test.js
+++ b/source/MessageFormatter.test.js
@@ -151,8 +151,8 @@ describe('MessageFormatter', function() {
 		});
 	});
 
-	describe('#rich', function () {
-		test('Rich formatting works on simple string', function () {
+	describe('#rich', function() {
+		test('Rich formatting works on simple string', function() {
 			let formatter = new MessageFormatter('en-NZ', {
 				plural: pluralTypeHandler,
 				select: selectTypeHandler
@@ -163,7 +163,7 @@ describe('MessageFormatter', function() {
 			expect(result).toStrictEqual(['simple text']);
 		});
 
-		test('Rich formatting applies default formatter to string with tags', function () {
+		test('Rich formatting applies default formatter to string with tags', function() {
 			let formatter = new MessageFormatter('en-NZ', {
 				plural: pluralTypeHandler,
 				select: selectTypeHandler
@@ -174,7 +174,7 @@ describe('MessageFormatter', function() {
 			expect(result).toStrictEqual(['have a ', '<a>link!</a>']);
 		});
 
-		test('Rich formatting applies custom formatter to string with tags', function () {
+		test('Rich formatting applies custom formatter to string with tags', function() {
 			const customFormatter = (tag, tags, contents) => {
 				return { tag, contents };
 			};

--- a/source/MessageFormatter.test.js
+++ b/source/MessageFormatter.test.js
@@ -150,4 +150,43 @@ describe('MessageFormatter', function() {
 			expect(formatter.format(message, { 'gender_of_host': 'other', host: 'John', 'num_guests': 12345, guest: 'you' })).toBe('John invites you and # other people to their party.');
 		});
 	});
+
+	describe('#rich', function () {
+		test('Rich formatting works on simple string', function () {
+			let formatter = new MessageFormatter('en-NZ', {
+				plural: pluralTypeHandler,
+				select: selectTypeHandler
+			});
+
+			let result = formatter.rich('simple text');
+
+			expect(result).toStrictEqual(['simple text']);
+		});
+
+		test('Rich formatting applies default formatter to string with tags', function () {
+			let formatter = new MessageFormatter('en-NZ', {
+				plural: pluralTypeHandler,
+				select: selectTypeHandler
+			});
+
+			let result = formatter.rich('have a <a>link!</a>');
+
+			expect(result).toStrictEqual(['have a ', '<a>link!</a>']);
+		});
+
+		test('Rich formatting applies custom formatter to string with tags', function () {
+			const customFormatter = (tag, tags, contents) => {
+				return { tag, contents };
+			};
+
+			let formatter = new MessageFormatter('en-NZ', {
+				plural: pluralTypeHandler,
+				select: selectTypeHandler
+			}, customFormatter);
+
+			let result = formatter.rich('have a <a>link!</a>');
+
+			expect(result).toStrictEqual(['have a ', {contents: ['link!'], tag: 'a'}]);
+		});
+	});
 });

--- a/source/defaultRichHandler.js
+++ b/source/defaultRichHandler.js
@@ -1,3 +1,3 @@
 export function defaultRichHandler(tag, tags, contents) {
-    return `<${tag}>${contents}</${tag}>`;
+	return `<${tag}>${contents}</${tag}>`;
 }

--- a/source/defaultRichHandler.js
+++ b/source/defaultRichHandler.js
@@ -1,0 +1,3 @@
+export function defaultRichHandler(tag, tags, contents) {
+    return `<${tag}>${contents}</${tag}>`;
+}

--- a/source/defaultRichHandler.test.js
+++ b/source/defaultRichHandler.test.js
@@ -1,0 +1,41 @@
+/* 
+ * Copyright 2019, Emanuel Rabina (http://www.ultraq.net.nz/)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env jest */
+import { defaultRichHandler } from './defaultRichHandler';
+
+/**
+ * Tests for the ICU message formatter.
+ */
+describe('defaultRichHandler', function () {
+
+    describe('#format', function () {
+        test('Returns simple string', function () {
+            let result = defaultRichHandler("a", "literally anything", "Contents")
+            expect(result).toBe('<a>Contents</a>');
+        });
+
+        test('Works with empty contents', function () {
+            let result = defaultRichHandler("a", "literally anything", "")
+            expect(result).toBe('<a></a>');
+        });
+
+        test('Works with empty tag and contents', function () {
+            let result = defaultRichHandler("", "literally anything", "")
+            expect(result).toBe('<></>');
+        });
+    });
+});

--- a/source/defaultRichHandler.test.js
+++ b/source/defaultRichHandler.test.js
@@ -20,22 +20,22 @@ import { defaultRichHandler } from './defaultRichHandler';
 /**
  * Tests for the ICU message formatter.
  */
-describe('defaultRichHandler', function () {
+describe('defaultRichHandler', function() {
 
-    describe('#format', function () {
-        test('Returns simple string', function () {
-            let result = defaultRichHandler("a", "literally anything", "Contents")
-            expect(result).toBe('<a>Contents</a>');
-        });
+	describe('#format', function() {
+		test('Returns simple string', function() {
+			let result = defaultRichHandler('a', 'literally anything', 'Contents');
+			expect(result).toBe('<a>Contents</a>');
+		});
 
-        test('Works with empty contents', function () {
-            let result = defaultRichHandler("a", "literally anything", "")
-            expect(result).toBe('<a></a>');
-        });
+		test('Works with empty contents', function() {
+			let result = defaultRichHandler('a', 'literally anything', '');
+			expect(result).toBe('<a></a>');
+		});
 
-        test('Works with empty tag and contents', function () {
-            let result = defaultRichHandler("", "literally anything", "")
-            expect(result).toBe('<></>');
-        });
-    });
+		test('Works with empty tag and contents', function() {
+			let result = defaultRichHandler('', 'literally anything', '');
+			expect(result).toBe('<></>');
+		});
+	});
 });

--- a/source/utilities.js
+++ b/source/utilities.js
@@ -97,6 +97,162 @@ export function parseCases(string) {
 }
 
 /**
+ * Replaces rich tags with elements, as per a provided handler.
+ * No spaces allowed in tag name, syntax MUST be <TAG_NAME>SOME_CONTENTS</TAG_NAME>.
+ * Currently does not support tags with attributes.
+ * Currently does not support self closing tags.
+ * 
+ * @param {String[]|any[]} message
+ */
+export function replaceRichTags(message, tags, handler) {
+	const isHtmlTagChar = ch => /[a-zA-Z-_]/.test(ch);
+	const result = [];
+
+	for (let i = 0; i < message.length; i++) {
+		const segment = message[i];
+		if (typeof segment !== 'string') {
+			result.push(segment);
+			continue;
+		}
+
+		let j = 0;
+		let currTagStart = null;
+		let inTag = false
+
+		let processedSegment = false;
+		while (j < segment.length) {
+			// Start of potential tag
+			if (!inTag && segment[j] === '<') {
+				currTagStart = j;
+				inTag = true;
+			}
+
+			// Tag ended
+			else if (inTag && segment[j] === '>') {
+				const currTag = segment.slice(currTagStart + 1, j);
+				const endingLocation = findClosingTag(message, currTag, i, j);
+
+				if (!endingLocation) {
+					throw new Error(`Unbalanced tags: no closing tag found for <${currTag}>`);
+				}
+
+				const entireTagInSegment = endingLocation.segmentIndex === i;
+				const segmentContainingClosingTag = message[endingLocation.segmentIndex];
+
+				const tagContents = [];
+
+				if (entireTagInSegment) {
+					tagContents.push(segment.slice(j + 1, endingLocation.segmentStart));
+				} else {
+					tagContents.push(segment.slice(j + 1));
+
+					for (let k = i + 1; k < endingLocation.segmentIndex; k++) {
+						tagContents.push(message[k]);
+					}
+					tagContents.push(segmentContainingClosingTag.slice(0, endingLocation.segmentStart));
+				}
+
+				result.push(segment.slice(0, currTagStart));
+
+				result.push(handler(currTag, tags, replaceRichTags(tagContents.filter(s => s !== ''), tags, handler)));
+
+				message.splice(endingLocation.segmentIndex + 1, 0, segmentContainingClosingTag.slice(endingLocation.segmentEnd + 1));
+
+				processedSegment = true;
+
+				// Will be advanced to the next segment at the end of the loop.
+				i = endingLocation.segmentIndex;
+
+				// We've spliced in any remainder of the current segment as the
+				// next segment. We want to immediately advance to that.
+				break;
+			}
+
+			// Not a valid tag, reset state.
+			else if (inTag && !isHtmlTagChar(segment[j])) {
+				currTagStart = null;
+				inTag = false;
+			}
+
+			j++;
+		}
+
+		if (!processedSegment) {
+			result.push(segment);
+		}
+	}
+
+	return result.filter(s => s !== '');
+}
+
+/**
+ * Finds the index of the matching closing tag, including through strings that
+ * could have nested tags.
+ */
+function findClosingTag(message, tag, startIndex, startSegmentIndex) {
+	const isHtmlTagChar = ch => /[a-zA-Z-_]/.test(ch);
+
+	let depth = 1;
+
+	for (let i = startIndex; i < message.length; i++) {
+		const segment = message[i];
+
+		if (typeof segment !== 'string') {
+			continue;
+		}
+
+		let currTagIsClosing = false;
+		let currTagStart = null;
+		let inTag = false
+		const startJ = i === startIndex ? startSegmentIndex : 0;
+		for (let j = startJ; j < segment.length; j++) {
+			// Start of tag
+			if (!inTag && segment[j] === '<') {
+				currTagStart = j;
+				inTag = true;
+
+				if (segment[j + 1] === '/') {
+					currTagIsClosing = true;
+					j++;
+				}
+			}
+
+			// Tag ended
+			else if (inTag && segment[j] === '>') {
+				const currTag = segment.slice(currTagStart + 1 + currTagIsClosing, j);
+
+				if (currTag === tag) {
+					if (currTagIsClosing) {
+						depth--;
+					} else {
+						depth++;
+					}
+
+					if (depth === 0) {
+						return {
+							segmentIndex: i,
+							segmentStart: currTagStart,
+							segmentEnd: j
+						}
+					}
+				}
+
+				currTagIsClosing = false;
+				currTagStart = null;
+				inTag = false;
+			}
+
+			// Not a valid tag, reset state.
+			else if (inTag && !isHtmlTagChar(segment[j])) {
+				currTagIsClosing = false;
+				currTagStart = null;
+				inTag = false;
+			}
+		}
+	}
+}
+
+/**
  * Finds the index of the matching closing curly bracket, including through
  * strings that could have nested brackets.
  * 

--- a/source/utilities.js
+++ b/source/utilities.js
@@ -103,6 +103,9 @@ export function parseCases(string) {
  * Currently does not support self closing tags.
  * 
  * @param {String[]|any[]} message
+ * @param {Object} tags
+ * @param {Function} handler
+ * @return {String[]|any[]}
  */
 export function replaceRichTags(message, tags, handler) {
 	const isHtmlTagChar = ch => /[a-zA-Z-_]/.test(ch);
@@ -117,7 +120,7 @@ export function replaceRichTags(message, tags, handler) {
 
 		let j = 0;
 		let currTagStart = null;
-		let inTag = false
+		let inTag = false;
 
 		let processedSegment = false;
 		while (j < segment.length) {
@@ -143,7 +146,8 @@ export function replaceRichTags(message, tags, handler) {
 
 				if (entireTagInSegment) {
 					tagContents.push(segment.slice(j + 1, endingLocation.segmentStart));
-				} else {
+				}
+				else {
 					tagContents.push(segment.slice(j + 1));
 
 					for (let k = i + 1; k < endingLocation.segmentIndex; k++) {
@@ -188,6 +192,12 @@ export function replaceRichTags(message, tags, handler) {
 /**
  * Finds the index of the matching closing tag, including through strings that
  * could have nested tags.
+ * 
+ * @param {String[]|any[]} message
+ * @param {String} tag
+ * @param {Number} startIndex
+ * @param {Number} startSegmentIndex
+ * @return {Boolean}
  */
 function findClosingTag(message, tag, startIndex, startSegmentIndex) {
 	const isHtmlTagChar = ch => /[a-zA-Z-_]/.test(ch);
@@ -203,7 +213,7 @@ function findClosingTag(message, tag, startIndex, startSegmentIndex) {
 
 		let currTagIsClosing = false;
 		let currTagStart = null;
-		let inTag = false
+		let inTag = false;
 		const startJ = i === startIndex ? startSegmentIndex : 0;
 		for (let j = startJ; j < segment.length; j++) {
 			// Start of tag
@@ -224,7 +234,8 @@ function findClosingTag(message, tag, startIndex, startSegmentIndex) {
 				if (currTag === tag) {
 					if (currTagIsClosing) {
 						depth--;
-					} else {
+					}
+					else {
 						depth++;
 					}
 
@@ -233,7 +244,7 @@ function findClosingTag(message, tag, startIndex, startSegmentIndex) {
 							segmentIndex: i,
 							segmentStart: currTagStart,
 							segmentEnd: j
-						}
+						};
 					}
 				}
 

--- a/source/utilities.js
+++ b/source/utilities.js
@@ -114,7 +114,7 @@ export function replaceRichTags(message, tags, handler) {
 		if (currTagIsClosing) {
 			return {
 				break: true
-			}
+			};
 		}
 
 		const endingLocation = findClosingTag(message, currTag, i, j);
@@ -148,7 +148,7 @@ export function replaceRichTags(message, tags, handler) {
 
 
 		return { processedSegment: true, newSegmentIndex: endingLocation.segmentIndex, break: true };
-	}
+	};
 
 	traverseMessageTags(message, 0, 0, result, onTagClose);
 
@@ -185,12 +185,12 @@ function findClosingTag(message, tag, startIndex, startSegmentIndex) {
 					segmentEnd: j
 				};
 
-				return { exit: true }
+				return { exit: true };
 			}
 		}
 
 		return { exit: false };
-	}
+	};
 
 	traverseMessageTags(message, startIndex, startSegmentIndex, [], onTagClose);
 
@@ -230,10 +230,18 @@ function traverseMessageTags(message, startI, startJ, result, onTagClose) {
 
 				const instructions = onTagClose(segment, currTagIsClosing, currTag, i, j, currTagStart);
 
-				if (instructions.exit) return;
-				if (instructions.newSegmentIndex) i = instructions.newSegmentIndex;
-				if (instructions.processedSegment) processedSegment = true;
-				if (instructions.break) break;
+				if (instructions.exit) {
+					return;
+				}
+				if (instructions.newSegmentIndex) {
+					i = instructions.newSegmentIndex;
+				}
+				if (instructions.processedSegment) {
+					processedSegment = true;
+				}
+				if (instructions.break) {
+					break;
+				}
 
 				currTagIsClosing = false;
 				currTagStart = null;

--- a/source/utilities.test.js
+++ b/source/utilities.test.js
@@ -15,46 +15,46 @@
  */
 
 /* eslint-env jest */
-import { parseCases } from './utilities';
+import { parseCases, replaceRichTags } from './utilities';
 
 /**
  * Tests for the `parseCases` util.
  */
-describe('parseCases', function() {
-	describe('empty', function() {
-		test('empty string', function() {
+describe('parseCases', function () {
+	describe('empty', function () {
+		test('empty string', function () {
 			let result = parseCases('');
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({});
 		});
 	});
 
-	describe('basic case support', function() {
-		test('single case', function() {
+	describe('basic case support', function () {
+		test('single case', function () {
 			let result = parseCases('key {case string!}');
 			expect(result.args).toStrictEqual([]);
-			expect(result.cases).toStrictEqual({key: 'case string!'});
+			expect(result.cases).toStrictEqual({ key: 'case string!' });
 		});
 
-		test('fails if cant close case', function() {
+		test('fails if cant close case', function () {
 			expect(() => {
 				parseCases('key1 {{case1}');
 			}).toThrowError();
 		});
 
-		test('multiple cases', function() {
+		test('multiple cases', function () {
 			let result = parseCases('key1 {case1} key2 {case2} key3 {case3}');
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({ key1: 'case1', key2: 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with symbols', function() {
+		test('multiple cases with symbols', function () {
 			let result = parseCases('=key1 {case1} &key2 {case2} key3 {case3}');
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({ '=key1': 'case1', '&key2': 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with inconsistent whitespace', function() {
+		test('multiple cases with inconsistent whitespace', function () {
 			let result = parseCases(`key1     {case1}  
             
             
@@ -64,13 +64,13 @@ describe('parseCases', function() {
 			expect(result.cases).toStrictEqual({ key1: 'case1', key2: 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with minimal whitespace', function() {
+		test('multiple cases with minimal whitespace', function () {
 			let result = parseCases(`key1{case1}key2{case2}key3{case3}`);
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({ key1: 'case1', key2: 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with complex bodies', function() {
+		test('multiple cases with complex bodies', function () {
 			let result = parseCases(`key1     {{}{}{}{{{{}}}}}  
             
             
@@ -81,18 +81,18 @@ describe('parseCases', function() {
 		});
 	});
 
-	describe('basic arg support', function() {
-		test('single arg', function() {
+	describe('basic arg support', function () {
+		test('single arg', function () {
 			let result = parseCases('arg1');
 			expect(result.args).toStrictEqual(['arg1']);
 		});
 
-		test('multiple args', function() {
+		test('multiple args', function () {
 			let result = parseCases('arg1 arg2 arg3');
 			expect(result.args).toStrictEqual(['arg1', 'arg2', 'arg3']);
 		});
 
-		test('multiple args with inconsistent whitespace', function() {
+		test('multiple args with inconsistent whitespace', function () {
 			let result = parseCases(`arg1     
             
             
@@ -101,8 +101,8 @@ describe('parseCases', function() {
 		});
 	});
 
-	describe('arg and cases support', function() {
-		test('multiple args and cases', function() {
+	describe('arg and cases support', function () {
+		test('multiple args and cases', function () {
 			let result = parseCases(`
             offset:1 something:else
               =0    {{host} does not give a party.}
@@ -118,6 +118,196 @@ describe('parseCases', function() {
 				'=2': '{host} invites {guest} and one other person to her party.',
 				other: '{host} invites {guest} and # other people to her party.'
 			});
+		});
+	});
+});
+
+describe('replaceRichTags', function () {
+	const replaceWithObject = (tag, tags, contents) => {
+		return { tag, contents };
+	};
+	
+	describe('No tags', function () {
+		test('Doesnt change single empty string', function () {
+			let result = replaceRichTags(["no tags here!"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['no tags here!']);
+		})
+
+		test('Doesnt change multiple empty strings', function () {
+			let result = replaceRichTags(["no", "tags", "here!"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['no', 'tags', 'here!']);
+		})
+	})
+
+	describe('Invalid tags', function () {
+		test('No spaces in tags', function () {
+			let result;
+
+			result = replaceRichTags(["<a >Hello!</a>"], {}, replaceWithObject);
+			expect(result).toStrictEqual(["<a >Hello!</a>"]);
+
+			result = replaceRichTags(["< a>Hello!</a>"], {}, replaceWithObject);
+			expect(result).toStrictEqual(["< a>Hello!</a>"]);
+		})
+	
+		test('No attributes', function () {
+			let result = replaceRichTags(["<a src='hello world'>Hello!</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(["<a src='hello world'>Hello!</a>"]);
+		})
+
+		test('No self-closing tags', function () {
+			let result = replaceRichTags(["Hello World <br />"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(["Hello World <br />"]);
+		})
+
+		test('Errors when tag unclosed', function () {
+			expect(() => {
+				replaceRichTags(["<a>Hello!"], {}, replaceWithObject);
+			}).toThrowError();
+		});
+
+		test('Doesnt change multiple empty strings', function () {
+			let result = replaceRichTags(["no", "tags", "here!"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['no', 'tags', 'here!']);
+		})
+
+		test('Passes through non-string segments', function () {
+
+			let result = replaceRichTags(["no", "tags", 42, "here!"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['no', 'tags', 42, 'here!']);
+		})
+	})
+
+	describe('Single tag', function () {
+		test('Replaces simple tag', function () {
+			let result = replaceRichTags(["<a>Hello!</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello!'], tag: 'a' }]);
+		});
+
+		test('Replaces simple tag with surrounding text', function () {
+			let result = replaceRichTags(["Some Prefix <a>Hello!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+		});
+
+		test('Replaces simple tag in consecutive segments', function () {
+			let result = replaceRichTags(["<a>Hello", "world</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello', 'world'], tag: 'a' }]);
+		});
+
+		test('Replaces simple tag in consecutive segments with surrounding text', function () {
+			let result = replaceRichTags(["Some Prefix <a>Hello", "world</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+		});
+
+		test('Replaces simple tag in disconnected segments', function () {
+			let result = replaceRichTags(["<a>Hello", "beautiful", "world</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello', 'beautiful', 'world'], tag: 'a' }]);
+		});
+
+		test('Replaces simple tag in disconnected segments with surrounding text', function () {
+			let result = replaceRichTags(["Some Prefix <a>Hello", "beautiful", "world</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+		});
+
+		test('includes non-string contents', function () {
+			let result = replaceRichTags(["<a>Hello, ", 42, " world</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello, ', 42, ' world'], tag: 'a' }]);
+		});
+	})
+
+	describe('disjoint tags', function () {
+		test('Replaces disjoint tags', function () {
+			let result = replaceRichTags(["<a>Hello!</a> <a>Hello 2!</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello!'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }]);
+		});
+
+		test('Replaces disjoint tags with surrounding text', function () {
+			let result = replaceRichTags(["Some Prefix <a>Hello!</a> <a>Hello 2!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello!'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+		});
+
+		test('Replaces disjoint tags, one split one not', function () {
+			let result = replaceRichTags(["<a>Hello", "world</a> <a>Hello 2!</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }]);
+		});
+
+		test('Replaces disjoint tags, one split one not in consecutive segments with surrounding text', function () {
+			let result = replaceRichTags(["Some Prefix <a>Hello", "world</a> <a>Hello 2!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+		});
+
+		test('Replaces disjoint tags, both split', function () {
+			let result = replaceRichTags(["<a>Hello", "world</a> <a>Hello", " 2!</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello', ' 2!'], tag: 'a' }]);
+		});
+
+		test('Replaces disjoint tags, both split in consecutive segments with surrounding text', function () {
+			let result = replaceRichTags(["Some Prefix <a>Hello", "world</a> <a>Hello", " 2!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello', ' 2!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+		});
+
+
+		test('Replaces disjoint tags in disconnected segments', function () {
+			let result = replaceRichTags(["<a>Hello", "beautiful", "world</a><a>", "Pizza", "is", "good", "</a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, { contents: ['Pizza', 'is', 'good'], tag: 'a' }]);
+		});
+
+		test('Replaces disjoint tags in disconnected segments with surrounding text', function () {
+			let result = replaceRichTags(["Some Prefix <a>Hello", "beautiful", "world</a><a>", "Pizza", "is", "good", "</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, { contents: ['Pizza', 'is', 'good'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+		});
+	});
+
+	describe('nested tags', function () {
+		test('nested different tags', function () {
+			let result = replaceRichTags(["<a><b>Hello!</b></a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: [{ contents: ['Hello!'], tag: 'b' }], tag: 'a' }]);
+		});
+
+		test('nested different tags with surrounding text', function () {
+			let result = replaceRichTags(["PreOuter<a>PreInner<b>Hello!</b>PostInner</a>PostOuter"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['PreOuter', { contents: ['PreInner', { contents: ['Hello!'], tag: 'b' }, 'PostInner'], tag: 'a' }, 'PostOuter']);
+		});
+
+		test('nested same tags', function () {
+			let result = replaceRichTags(["<a><a>Hello!</a></a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: [{ contents: ['Hello!'], tag: 'a' }], tag: 'a' }]);
+		});
+
+		test('nested same tags with surrounding text', function () {
+			let result = replaceRichTags(["PreOuter<a>PreInner<a>Hello!</a>PostInner</a>PostOuter"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual(['PreOuter', { contents: ['PreInner', { contents: ['Hello!'], tag: 'a' }, 'PostInner'], tag: 'a' }, 'PostOuter']);
+		});
+
+		test('nested invalid inner ignored', function () {
+			let result = replaceRichTags(["<a>< b>Hello!</b></a>"], {}, replaceWithObject);
+
+			expect(result).toStrictEqual([{ contents: ['< b>Hello!</b>'], tag: 'a' }]);
 		});
 	});
 });

--- a/source/utilities.test.js
+++ b/source/utilities.test.js
@@ -20,41 +20,41 @@ import { parseCases, replaceRichTags } from './utilities';
 /**
  * Tests for the `parseCases` util.
  */
-describe('parseCases', function () {
-	describe('empty', function () {
-		test('empty string', function () {
+describe('parseCases', function() {
+	describe('empty', function() {
+		test('empty string', function() {
 			let result = parseCases('');
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({});
 		});
 	});
 
-	describe('basic case support', function () {
-		test('single case', function () {
+	describe('basic case support', function() {
+		test('single case', function() {
 			let result = parseCases('key {case string!}');
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({ key: 'case string!' });
 		});
 
-		test('fails if cant close case', function () {
+		test('fails if cant close case', function() {
 			expect(() => {
 				parseCases('key1 {{case1}');
 			}).toThrowError();
 		});
 
-		test('multiple cases', function () {
+		test('multiple cases', function() {
 			let result = parseCases('key1 {case1} key2 {case2} key3 {case3}');
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({ key1: 'case1', key2: 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with symbols', function () {
+		test('multiple cases with symbols', function() {
 			let result = parseCases('=key1 {case1} &key2 {case2} key3 {case3}');
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({ '=key1': 'case1', '&key2': 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with inconsistent whitespace', function () {
+		test('multiple cases with inconsistent whitespace', function() {
 			let result = parseCases(`key1     {case1}  
             
             
@@ -64,13 +64,13 @@ describe('parseCases', function () {
 			expect(result.cases).toStrictEqual({ key1: 'case1', key2: 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with minimal whitespace', function () {
+		test('multiple cases with minimal whitespace', function() {
 			let result = parseCases(`key1{case1}key2{case2}key3{case3}`);
 			expect(result.args).toStrictEqual([]);
 			expect(result.cases).toStrictEqual({ key1: 'case1', key2: 'case2', key3: 'case3' });
 		});
 
-		test('multiple cases with complex bodies', function () {
+		test('multiple cases with complex bodies', function() {
 			let result = parseCases(`key1     {{}{}{}{{{{}}}}}  
             
             
@@ -81,18 +81,18 @@ describe('parseCases', function () {
 		});
 	});
 
-	describe('basic arg support', function () {
-		test('single arg', function () {
+	describe('basic arg support', function() {
+		test('single arg', function() {
 			let result = parseCases('arg1');
 			expect(result.args).toStrictEqual(['arg1']);
 		});
 
-		test('multiple args', function () {
+		test('multiple args', function() {
 			let result = parseCases('arg1 arg2 arg3');
 			expect(result.args).toStrictEqual(['arg1', 'arg2', 'arg3']);
 		});
 
-		test('multiple args with inconsistent whitespace', function () {
+		test('multiple args with inconsistent whitespace', function() {
 			let result = parseCases(`arg1     
             
             
@@ -101,8 +101,8 @@ describe('parseCases', function () {
 		});
 	});
 
-	describe('arg and cases support', function () {
-		test('multiple args and cases', function () {
+	describe('arg and cases support', function() {
+		test('multiple args and cases', function() {
 			let result = parseCases(`
             offset:1 something:else
               =0    {{host} does not give a party.}
@@ -122,190 +122,190 @@ describe('parseCases', function () {
 	});
 });
 
-describe('replaceRichTags', function () {
+describe('replaceRichTags', function() {
 	const replaceWithObject = (tag, tags, contents) => {
 		return { tag, contents };
 	};
-	
-	describe('No tags', function () {
-		test('Doesnt change single empty string', function () {
-			let result = replaceRichTags(["no tags here!"], {}, replaceWithObject);
+
+	describe('No tags', function() {
+		test('Doesnt change single empty string', function() {
+			let result = replaceRichTags(['no tags here!'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual(['no tags here!']);
-		})
+		});
 
-		test('Doesnt change multiple empty strings', function () {
-			let result = replaceRichTags(["no", "tags", "here!"], {}, replaceWithObject);
+		test('Doesnt change multiple empty strings', function() {
+			let result = replaceRichTags(['no', 'tags', 'here!'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual(['no', 'tags', 'here!']);
-		})
-	})
+		});
+	});
 
-	describe('Invalid tags', function () {
-		test('No spaces in tags', function () {
+	describe('Invalid tags', function() {
+		test('No spaces in tags', function() {
 			let result;
 
-			result = replaceRichTags(["<a >Hello!</a>"], {}, replaceWithObject);
-			expect(result).toStrictEqual(["<a >Hello!</a>"]);
+			result = replaceRichTags(['<a >Hello!</a>'], {}, replaceWithObject);
+			expect(result).toStrictEqual(['<a >Hello!</a>']);
 
-			result = replaceRichTags(["< a>Hello!</a>"], {}, replaceWithObject);
-			expect(result).toStrictEqual(["< a>Hello!</a>"]);
-		})
-	
-		test('No attributes', function () {
+			result = replaceRichTags(['< a>Hello!</a>'], {}, replaceWithObject);
+			expect(result).toStrictEqual(['< a>Hello!</a>']);
+		});
+
+		test('No attributes', function() {
 			let result = replaceRichTags(["<a src='hello world'>Hello!</a>"], {}, replaceWithObject);
 
 			expect(result).toStrictEqual(["<a src='hello world'>Hello!</a>"]);
-		})
+		});
 
-		test('No self-closing tags', function () {
-			let result = replaceRichTags(["Hello World <br />"], {}, replaceWithObject);
+		test('No self-closing tags', function() {
+			let result = replaceRichTags(['Hello World <br />'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(["Hello World <br />"]);
-		})
+			expect(result).toStrictEqual(['Hello World <br />']);
+		});
 
-		test('Errors when tag unclosed', function () {
+		test('Errors when tag unclosed', function() {
 			expect(() => {
-				replaceRichTags(["<a>Hello!"], {}, replaceWithObject);
+				replaceRichTags(['<a>Hello!'], {}, replaceWithObject);
 			}).toThrowError();
 		});
 
-		test('Doesnt change multiple empty strings', function () {
-			let result = replaceRichTags(["no", "tags", "here!"], {}, replaceWithObject);
+		test('Doesnt change multiple empty strings', function() {
+			let result = replaceRichTags(['no', 'tags', 'here!'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual(['no', 'tags', 'here!']);
-		})
+		});
 
-		test('Passes through non-string segments', function () {
+		test('Passes through non-string segments', function() {
 
-			let result = replaceRichTags(["no", "tags", 42, "here!"], {}, replaceWithObject);
+			let result = replaceRichTags(['no', 'tags', 42, 'here!'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual(['no', 'tags', 42, 'here!']);
-		})
-	})
+		});
+	});
 
-	describe('Single tag', function () {
-		test('Replaces simple tag', function () {
-			let result = replaceRichTags(["<a>Hello!</a>"], {}, replaceWithObject);
+	describe('Single tag', function() {
+		test('Replaces simple tag', function() {
+			let result = replaceRichTags(['<a>Hello!</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello!'], tag: 'a' }]);
 		});
 
-		test('Replaces simple tag with surrounding text', function () {
-			let result = replaceRichTags(["Some Prefix <a>Hello!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+		test('Replaces simple tag with surrounding text', function() {
+			let result = replaceRichTags(['Some Prefix <a>Hello!</a> Some Suffix', 'Next Segment'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello!'], tag: 'a' }, ' Some Suffix', 'Next Segment']);
 		});
 
-		test('Replaces simple tag in consecutive segments', function () {
-			let result = replaceRichTags(["<a>Hello", "world</a>"], {}, replaceWithObject);
+		test('Replaces simple tag in consecutive segments', function() {
+			let result = replaceRichTags(['<a>Hello', 'world</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello', 'world'], tag: 'a' }]);
 		});
 
-		test('Replaces simple tag in consecutive segments with surrounding text', function () {
-			let result = replaceRichTags(["Some Prefix <a>Hello", "world</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+		test('Replaces simple tag in consecutive segments with surrounding text', function() {
+			let result = replaceRichTags(['Some Prefix <a>Hello', 'world</a> Some Suffix', 'Next Segment'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' Some Suffix', 'Next Segment']);
 		});
 
-		test('Replaces simple tag in disconnected segments', function () {
-			let result = replaceRichTags(["<a>Hello", "beautiful", "world</a>"], {}, replaceWithObject);
+		test('Replaces simple tag in disconnected segments', function() {
+			let result = replaceRichTags(['<a>Hello', 'beautiful', 'world</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello', 'beautiful', 'world'], tag: 'a' }]);
 		});
 
-		test('Replaces simple tag in disconnected segments with surrounding text', function () {
-			let result = replaceRichTags(["Some Prefix <a>Hello", "beautiful", "world</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+		test('Replaces simple tag in disconnected segments with surrounding text', function() {
+			let result = replaceRichTags(['Some Prefix <a>Hello', 'beautiful', 'world</a> Some Suffix', 'Next Segment'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, ' Some Suffix', 'Next Segment']);
 		});
 
-		test('includes non-string contents', function () {
-			let result = replaceRichTags(["<a>Hello, ", 42, " world</a>"], {}, replaceWithObject);
+		test('includes non-string contents', function() {
+			let result = replaceRichTags(['<a>Hello, ', 42, ' world</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello, ', 42, ' world'], tag: 'a' }]);
 		});
-	})
+	});
 
-	describe('disjoint tags', function () {
-		test('Replaces disjoint tags', function () {
-			let result = replaceRichTags(["<a>Hello!</a> <a>Hello 2!</a>"], {}, replaceWithObject);
+	describe('disjoint tags', function() {
+		test('Replaces disjoint tags', function() {
+			let result = replaceRichTags(['<a>Hello!</a> <a>Hello 2!</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello!'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }]);
 		});
 
-		test('Replaces disjoint tags with surrounding text', function () {
-			let result = replaceRichTags(["Some Prefix <a>Hello!</a> <a>Hello 2!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+		test('Replaces disjoint tags with surrounding text', function() {
+			let result = replaceRichTags(['Some Prefix <a>Hello!</a> <a>Hello 2!</a> Some Suffix', 'Next Segment'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello!'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello!'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }, ' Some Suffix', 'Next Segment']);
 		});
 
-		test('Replaces disjoint tags, one split one not', function () {
-			let result = replaceRichTags(["<a>Hello", "world</a> <a>Hello 2!</a>"], {}, replaceWithObject);
+		test('Replaces disjoint tags, one split one not', function() {
+			let result = replaceRichTags(['<a>Hello', 'world</a> <a>Hello 2!</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }]);
 		});
 
-		test('Replaces disjoint tags, one split one not in consecutive segments with surrounding text', function () {
-			let result = replaceRichTags(["Some Prefix <a>Hello", "world</a> <a>Hello 2!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+		test('Replaces disjoint tags, one split one not in consecutive segments with surrounding text', function() {
+			let result = replaceRichTags(['Some Prefix <a>Hello', 'world</a> <a>Hello 2!</a> Some Suffix', 'Next Segment'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello 2!'], tag: 'a' }, ' Some Suffix', 'Next Segment']);
 		});
 
-		test('Replaces disjoint tags, both split', function () {
-			let result = replaceRichTags(["<a>Hello", "world</a> <a>Hello", " 2!</a>"], {}, replaceWithObject);
+		test('Replaces disjoint tags, both split', function() {
+			let result = replaceRichTags(['<a>Hello', 'world</a> <a>Hello', ' 2!</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello', ' 2!'], tag: 'a' }]);
 		});
 
-		test('Replaces disjoint tags, both split in consecutive segments with surrounding text', function () {
-			let result = replaceRichTags(["Some Prefix <a>Hello", "world</a> <a>Hello", " 2!</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+		test('Replaces disjoint tags, both split in consecutive segments with surrounding text', function() {
+			let result = replaceRichTags(['Some Prefix <a>Hello', 'world</a> <a>Hello', ' 2!</a> Some Suffix', 'Next Segment'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello', ' 2!'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'world'], tag: 'a' }, ' ', { contents: ['Hello', ' 2!'], tag: 'a' }, ' Some Suffix', 'Next Segment']);
 		});
 
 
-		test('Replaces disjoint tags in disconnected segments', function () {
-			let result = replaceRichTags(["<a>Hello", "beautiful", "world</a><a>", "Pizza", "is", "good", "</a>"], {}, replaceWithObject);
+		test('Replaces disjoint tags in disconnected segments', function() {
+			let result = replaceRichTags(['<a>Hello', 'beautiful', 'world</a><a>', 'Pizza', 'is', 'good', '</a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, { contents: ['Pizza', 'is', 'good'], tag: 'a' }]);
 		});
 
-		test('Replaces disjoint tags in disconnected segments with surrounding text', function () {
-			let result = replaceRichTags(["Some Prefix <a>Hello", "beautiful", "world</a><a>", "Pizza", "is", "good", "</a> Some Suffix", "Next Segment"], {}, replaceWithObject);
+		test('Replaces disjoint tags in disconnected segments with surrounding text', function() {
+			let result = replaceRichTags(['Some Prefix <a>Hello', 'beautiful', 'world</a><a>', 'Pizza', 'is', 'good', '</a> Some Suffix', 'Next Segment'], {}, replaceWithObject);
 
-			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, { contents: ['Pizza', 'is', 'good'], tag: 'a' }, ' Some Suffix', "Next Segment"]);
+			expect(result).toStrictEqual(['Some Prefix ', { contents: ['Hello', 'beautiful', 'world'], tag: 'a' }, { contents: ['Pizza', 'is', 'good'], tag: 'a' }, ' Some Suffix', 'Next Segment']);
 		});
 	});
 
-	describe('nested tags', function () {
-		test('nested different tags', function () {
-			let result = replaceRichTags(["<a><b>Hello!</b></a>"], {}, replaceWithObject);
+	describe('nested tags', function() {
+		test('nested different tags', function() {
+			let result = replaceRichTags(['<a><b>Hello!</b></a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: [{ contents: ['Hello!'], tag: 'b' }], tag: 'a' }]);
 		});
 
-		test('nested different tags with surrounding text', function () {
-			let result = replaceRichTags(["PreOuter<a>PreInner<b>Hello!</b>PostInner</a>PostOuter"], {}, replaceWithObject);
+		test('nested different tags with surrounding text', function() {
+			let result = replaceRichTags(['PreOuter<a>PreInner<b>Hello!</b>PostInner</a>PostOuter'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual(['PreOuter', { contents: ['PreInner', { contents: ['Hello!'], tag: 'b' }, 'PostInner'], tag: 'a' }, 'PostOuter']);
 		});
 
-		test('nested same tags', function () {
-			let result = replaceRichTags(["<a><a>Hello!</a></a>"], {}, replaceWithObject);
+		test('nested same tags', function() {
+			let result = replaceRichTags(['<a><a>Hello!</a></a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: [{ contents: ['Hello!'], tag: 'a' }], tag: 'a' }]);
 		});
 
-		test('nested same tags with surrounding text', function () {
-			let result = replaceRichTags(["PreOuter<a>PreInner<a>Hello!</a>PostInner</a>PostOuter"], {}, replaceWithObject);
+		test('nested same tags with surrounding text', function() {
+			let result = replaceRichTags(['PreOuter<a>PreInner<a>Hello!</a>PostInner</a>PostOuter'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual(['PreOuter', { contents: ['PreInner', { contents: ['Hello!'], tag: 'a' }, 'PostInner'], tag: 'a' }, 'PostOuter']);
 		});
 
-		test('nested invalid inner ignored', function () {
-			let result = replaceRichTags(["<a>< b>Hello!</b></a>"], {}, replaceWithObject);
+		test('nested invalid inner ignored', function() {
+			let result = replaceRichTags(['<a>< b>Hello!</b></a>'], {}, replaceWithObject);
 
 			expect(result).toStrictEqual([{ contents: ['< b>Hello!</b>'], tag: 'a' }]);
 		});


### PR DESCRIPTION
This one is a bit more controversial than #10 and #9, as it's not strictly necessary to implement the ICU MessageFormat. We need it on our end, and I wanted to PR in case it might be useful.

Syntax is quite similar to https://formatjs.io/docs/intl-messageformat/, but there's no option to escape with single quotes. I can work on that if needed, but it might get complicated since we also need to account for apostrophes in regular usage.

Size changes:
Assuming #10 is merged, this would increase minified size from 3.547kB to 5.7kB. 