### PR TITLE
Use Intl.PluralRules

### DIFF
--- a/source/pluralTypeHandler.js
+++ b/source/pluralTypeHandler.js
@@ -16,6 +16,8 @@
 
 import {parseCases} from './utilities.js';
 
+let pluralFormatter;
+
 let keyCounter = 0;
 
 // All the special keywords that can be used in `plural` blocks for the various branches
@@ -87,6 +89,19 @@ export default function pluralTypeHandler(value, matches = '', locale, values, f
 
 	const keywordPossibilities = [];
 
+	if ('PluralRules' in Intl) {
+		// Effectively memoize because instantiation of `Int.*` objects is expensive.
+		if (pluralFormatter === undefined || pluralFormatter.resolvedOptions().locale !== locale) {
+			pluralFormatter = new Intl.PluralRules(locale);
+		}
+
+		const pluralKeyword = pluralFormatter.select(intValue);
+
+		// Other is always added last with least priority, so we don't want to add it here.
+		if (pluralKeyword !== OTHER) {
+			keywordPossibilities.push(pluralKeyword);
+		}
+	}
 	if (intValue === 1) {
 		keywordPossibilities.push(ONE);
 	}

--- a/source/pluralTypeHandler.test.js
+++ b/source/pluralTypeHandler.test.js
@@ -139,6 +139,46 @@ describe('pluralTypeHandler', function() {
 		});
 	});
 
+
+	describe('Intl PluralRules', function () {
+		const formatterAr = new MessageFormatter('ar', {
+			plural: pluralTypeHandler
+		});
+
+		const messageAr = `{value, plural,
+			zero {ZERO}
+			one {ONE}
+			two {TWO}
+			few {FEW}
+			other {OTHER}
+		}`;
+
+		test('zero', function () {
+			let result = formatterAr.format(messageAr, { value: 0 });
+			expect(result).toBe('ZERO');
+		});
+
+		test('one', function () {
+			let result = formatterAr.format(messageAr, { value: 1 });
+			expect(result).toBe('ONE');
+		});
+
+		test('two', function () {
+			let result = formatterAr.format(messageAr, { value: 2 });
+			expect(result).toBe('TWO');
+		});
+
+		test('few', function () {
+			let result = formatterAr.format(messageAr, { value: 3 });
+			expect(result).toBe('FEW');
+		});
+
+		test('other', function () {
+			let result = formatterAr.format(messageAr, { value: 17 });
+			expect(result).toBe('OTHER');
+		});
+	});
+
 	describe('Empty matches', function() {
 		test('No matching branch', function() {
 			let result = pluralTypeHandler('some value');


### PR DESCRIPTION
Currently the `pluralTypeHandler` provided by this library matches against literal `=n` values, as well as `one` and `other`. This doesn't work well for various locales, which can have different spellings for `zero`, `two`, `few`, `other`, and various other categories.

The `Intl.PluralRules` tool available in [all browsers other than IE11](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules#browser_compatibility) supports this directly in the browser without additional overhead. This PR adds this into the `pluralTypeHandler` if available (to not break IE11 compatibility).

Fixes https://github.com/flarum/core/issues/3072